### PR TITLE
Poweroff nvidia card before removing it

### DIFF
--- a/envycontrol.py
+++ b/envycontrol.py
@@ -42,7 +42,7 @@ ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000"
 ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"
 
 # Finally, remove the NVIDIA dGPU
-ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", ATTR{remove}="1"
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", ATTR{power/control}="auto", ATTR{remove}="1"
 '''
 
 # for Nvidia mode


### PR DESCRIPTION
I noticed the dGPU still keeps drawing power after being removed.
With this modification it gets powered down before being removed. *At least on my system.*
I'm not sure if this should be added to the remaining udev rules as well.